### PR TITLE
Add ChattyRental sample pages and components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# tripathv2
+# ChattyRental Example Code
+
+This repository contains example code snippets for a Next.js 14 application using Supabase and Stripe.
+
+## Setup
+
+Install dependencies (requires internet):
+
+```bash
+npm install next react react-dom @supabase/supabase-js stripe
+```
+
+Add Shadcn UI components:
+
+```bash
+npx shadcn-ui@latest add card button popover calendar
+```
+
+Configure environment variables for Supabase and Stripe in a `.env.local` file.
+
+## Project Structure
+
+- `types.ts` – TypeScript types for the Supabase schema.
+- `components/RoomCard.tsx` – UI component to display a room card.
+- `components/BookingWidget.tsx` – Client component for selecting dates and continuing to reservation.
+- `app/page.tsx` – Server page listing available rooms.
+- `app/room/[id]/page.tsx` – Server page showing room details with booking widget.
+- `app/reserve/[roomId]/page.tsx` – Client page for reservation and payment.
+- `app/actions.ts` – Server action to create a booking and start a Stripe Checkout session.

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,0 +1,42 @@
+'use server';
+import { createClient } from '@supabase/supabase-js';
+import Stripe from 'stripe';
+import { redirect } from 'next/navigation';
+
+const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2023-10-16' });
+
+export async function createBookingAndPay(formData: FormData) {
+  const name = String(formData.get('name'));
+  const email = String(formData.get('email'));
+  const roomId = String(formData.get('roomId'));
+  const startDate = formData.get('startDate') as string | null;
+  const endDate = formData.get('endDate') as string | null;
+
+  const { data: booking } = await supabase
+    .from('bookings')
+    .insert({ tenant_id: null, room_id: roomId, start_date: startDate, end_date: endDate, status: 'pending' })
+    .select()
+    .single();
+
+  const session = await stripe.checkout.sessions.create({
+    line_items: [
+      {
+        price_data: {
+          currency: 'eur',
+          product_data: { name: `Booking for room ${roomId}` },
+          unit_amount: 100 * 100, // placeholder price
+        },
+        quantity: 1,
+      },
+    ],
+    mode: 'payment',
+    success_url: `${process.env.NEXT_PUBLIC_BASE_URL}/booking/success`,
+    cancel_url: `${process.env.NEXT_PUBLIC_BASE_URL}/room/${roomId}`,
+    metadata: { booking_id: booking.id },
+    customer_email: email,
+    client_reference_id: name,
+  });
+
+  redirect(session.url!);
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,23 @@
+import { createClient } from '@supabase/supabase-js';
+import RoomCard from '../components/RoomCard';
+import { Room } from '../types';
+
+// Assume env vars SUPABASE_URL and SUPABASE_ANON_KEY are set
+const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_ANON_KEY!);
+
+export default async function Page() {
+  const { data } = await supabase
+    .from('rooms')
+    .select('*, property:properties(city, address)')
+    .eq('status', 'available');
+
+  const rooms = (data as (Room & { property: { city: string | null; address: string | null } })[]) || [];
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4">
+      {rooms.map(room => (
+        <RoomCard key={room.id} room={room} />
+      ))}
+    </div>
+  );
+}

--- a/app/reserve/[roomId]/page.tsx
+++ b/app/reserve/[roomId]/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { useSearchParams } from 'next/navigation';
+import { useState } from 'react';
+import { createBookingAndPay } from '../../actions';
+import { Button } from '@/components/ui/button';
+
+export default function ReservePage({ params }: { params: { roomId: string } }) {
+  const search = useSearchParams();
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+
+  const moveInDate = search.get('moveInDate');
+  const moveOutDate = search.get('moveOutDate');
+
+  async function onSubmit() {
+    const formData = new FormData();
+    formData.append('name', name);
+    formData.append('email', email);
+    formData.append('roomId', params.roomId);
+    if (moveInDate) formData.append('startDate', moveInDate);
+    if (moveOutDate) formData.append('endDate', moveOutDate);
+    await createBookingAndPay(formData);
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Confirm your booking</h1>
+      <p>Move in: {moveInDate}</p>
+      <p>Move out: {moveOutDate}</p>
+      <input
+        className="border p-2 w-full"
+        placeholder="Name"
+        value={name}
+        onChange={e => setName(e.target.value)}
+      />
+      <input
+        className="border p-2 w-full"
+        placeholder="Email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+      />
+      <Button onClick={onSubmit}>Confirm and Pay</Button>
+    </div>
+  );
+}

--- a/app/room/[id]/page.tsx
+++ b/app/room/[id]/page.tsx
@@ -1,0 +1,38 @@
+import { createClient } from '@supabase/supabase-js';
+import BookingWidget from '../../../components/BookingWidget';
+import { Room } from '../../../types';
+
+const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_ANON_KEY!);
+
+interface Props { params: { id: string } }
+
+export default async function RoomPage({ params }: Props) {
+  const { data } = await supabase
+    .from('rooms')
+    .select('*, property:properties(*)')
+    .eq('id', params.id)
+    .single();
+
+  if (!data) return <p>Room not found</p>;
+  const room = data as Room & { property: any };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-6 p-4">
+      <div className="md:col-span-2 space-y-4">
+        <h1 className="text-2xl font-bold">{room.title}</h1>
+        {Array.isArray(room.photos) && (
+          <div className="grid grid-cols-2 gap-2">
+            {room.photos.map((src: string) => (
+              <img key={src} src={src} alt={room.title} className="object-cover" />
+            ))}
+          </div>
+        )}
+        <p>{room.property.address}</p>
+        {room.property.video_url && (
+          <a href={room.property.video_url} target="_blank" className="underline">Video Tour</a>
+        )}
+      </div>
+      <BookingWidget price_monthly={room.price_monthly} deposit={room.deposit} roomId={room.id} />
+    </div>
+  );
+}

--- a/components/BookingWidget.tsx
+++ b/components/BookingWidget.tsx
@@ -1,0 +1,60 @@
+"use client";
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Calendar } from '@/components/ui/calendar';
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  price_monthly: number;
+  deposit: number | null;
+  roomId: string;
+}
+
+export default function BookingWidget({ price_monthly, deposit = 0, roomId }: Props) {
+  const router = useRouter();
+  const [moveInDate, setMoveInDate] = useState<Date | undefined>();
+  const [moveOutDate, setMoveOutDate] = useState<Date | undefined>();
+
+  const totalPrice = price_monthly + (deposit || 0);
+
+  return (
+    <div className="space-y-4 p-4 border rounded sticky top-4">
+      <p className="text-xl font-semibold">{price_monthly} € per month</p>
+      <div className="space-y-2">
+        <label>MOVE IN</label>
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="outline">{moveInDate?.toDateString() || 'Select date'}</Button>
+          </PopoverTrigger>
+          <PopoverContent>
+            <Calendar mode="single" selected={moveInDate} onSelect={setMoveInDate} />
+          </PopoverContent>
+        </Popover>
+      </div>
+      <div className="space-y-2">
+        <label>MOVE OUT</label>
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="outline">{moveOutDate?.toDateString() || 'Select date'}</Button>
+          </PopoverTrigger>
+          <PopoverContent>
+            <Calendar mode="single" selected={moveOutDate} onSelect={setMoveOutDate} />
+          </PopoverContent>
+        </Popover>
+      </div>
+      <p>Total: {totalPrice} €</p>
+      <Button
+        onClick={() => {
+          const params = new URLSearchParams({
+            moveInDate: moveInDate?.toISOString() || '',
+            moveOutDate: moveOutDate?.toISOString() || '',
+          });
+          router.push(`/reserve/${roomId}?` + params.toString());
+        }}
+      >
+        Continue
+      </Button>
+    </div>
+  );
+}

--- a/components/RoomCard.tsx
+++ b/components/RoomCard.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Room } from '../types';
+
+interface Props {
+  room: Room & { property?: { city: string | null; address: string | null } };
+}
+
+export default function RoomCard({ room }: Props) {
+  const image = Array.isArray(room.photos) ? room.photos[0] : null;
+  return (
+    <Card>
+      <CardHeader>
+        {image && <img src={image} alt={room.title} className="w-full h-48 object-cover" />}
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <h3 className="text-lg font-semibold">{room.title}</h3>
+        <p className="text-muted-foreground">{room.property?.city}, {room.property?.address}</p>
+        <div className="flex items-center justify-between">
+          <span className="font-bold">{room.price_monthly} €/al mes</span>
+          <span className="text-green-600 text-xs font-semibold">VERIFICADO</span>
+        </div>
+        <Link href={`/room/${room.id}`} className="underline text-primary">
+          Ver habitación
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "chattyrental",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.0.0",
+    "next": "14.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "stripe": "^13.0.0"
+  },
+  "type": "module"
+}

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,44 @@
+export type UserRole = 'tenant' | 'agency' | 'owner';
+export type RoomStatus = 'available' | 'reserved' | 'occupied';
+export type BookingStatus = 'pending' | 'paid' | 'confirmed' | 'cancelled';
+
+export interface User {
+  id: string;
+  role: UserRole;
+  name: string | null;
+  email: string;
+}
+
+export interface Property {
+  id: string;
+  title: string;
+  address: string | null;
+  city: string | null;
+  video_url: string | null;
+  photos: any; // JSONB
+  agency_id: string | null;
+}
+
+export interface Room {
+  id: string;
+  title: string;
+  size_m2: number | null;
+  price_monthly: number;
+  deposit: number | null;
+  bills_included: boolean | null;
+  available_from: string | null; // Date string
+  status: RoomStatus;
+  photos: any; // JSONB
+  property_id: string;
+  property?: Property; // joined data
+}
+
+export interface Booking {
+  id: string;
+  tenant_id: string | null;
+  room_id: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  status: BookingStatus;
+  contract_url: string | null;
+}


### PR DESCRIPTION
## Summary
- add Supabase schema types
- add RoomCard and BookingWidget components
- implement main page and room detail page
- implement reservation page and booking Stripe action
- document setup in README
- include example package.json

## Testing
- `npm install next@14 react react-dom @supabase/supabase-js stripe` *(fails: process terminated)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848061163f4832dac86be59d1ada08f